### PR TITLE
Fixes #6: Be more forgiving about spaces in content-types

### DIFF
--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -5,6 +5,7 @@ import requests
 from cStringIO import StringIO
 import csv
 import json
+import re
 
 __author__ = "Cristina Munoz <hi@xmunoz.com>"
 
@@ -200,12 +201,12 @@ class Socrata(object):
 
         # for other request types, return most useful data
         content_type = response.headers.get('content-type').strip().lower()
-        if content_type == "application/json; charset=utf-8":
+        if re.match(r'application/json;\s*charset=utf-8', content_type):
             return response.json()
-        elif content_type == "text/csv; charset=utf-8":
+        elif re.match(r'text/csv;\s*charset=utf-8', content_type):
             csv_stream = StringIO(response.text)
             return [line for line in csv.reader(csv_stream)]
-        elif content_type == "application/rdf+xml; charset=utf-8":
+        elif re.match(r'application/rdf+xml;\s*charset=utf-8', content_type):
             return response.content
         else:
             raise Exception("Unknown response format: {0}"


### PR DESCRIPTION
sodapy doesn't like the content type from SODA 2.1 APIs, since they
contain spaces. This matches by a more forgiving regexp.