### PR TITLE
Create dataset

### DIFF
--- a/README
+++ b/README
@@ -37,6 +37,23 @@ Retrieving data is easy! Use SQL-style keyword args to filter data, or lookup an
     >>> client.get("/resource/nimj-3ivp/193.json", exclude_system_fields=False)
     {u'geolocation': {u'latitude': u'21.6711', u'needs_recoding': False, u'longitude': u'142.9236'}, u'version': u'C', u':updated_at': 1348778988, u'number_of_stations': u'136', u'region': u'Mariana Islands region', u':created_meta': u'21484', u'occurred_at': u'2012-09-13T11:19:07', u':id': 193, u'source': u'us', u'depth': u'300.70', u'magnitude': u'4.4', u':meta': u'{\n}', u':updated_meta': u'21484', u':position': 193, u'earthquake_id': u'c000cmsq', u':created_at': 1348778988}	
 
+Create a dataset
+
+	>>> columns = [{"fieldName": "delegation", "name": "Delegation", "dataTypeName": "text"}, {"fieldName": "members", "name": "Members", "dataTypeName": "number"}]
+	>>> tags = ["politics", "geography"]
+	>>> client.create("Delegates", description="List of delegates", columns=columns, row_identifier="delegation", tags=tags, category="Transparency")
+	{u'id': u'2frc-hyvj', u'name': u'Foo Bar', u'description': u'test dataset', u'publicationStage': u'unpublished', u'columns': [ { u'name': u'Foo', u'dataTypeName': u'text', u'fieldName': u'foo', ... }, { u'name': u'Bar', u'dataTypeName': u'number', u'fieldName': u'bar', ... } ], u'metadata': { u'rowIdentifier': 230641051 }, ... }
+
+Publish a dataset after creating it (take it out of 'working copy' mode)
+
+	>>> client.publish("/resource/eb9n-hr43.json")
+	{u'id': u'2frc-hyvj', u'name': u'Foo Bar', u'description': u'test dataset', u'publicationStage': u'unpublished', u'columns': [ { u'name': u'Foo', u'dataTypeName': u'text', u'fieldName': u'foo', ... }, { u'name': u'Bar', u'dataTypeName': u'number', u'fieldName': u'bar', ... } ], u'metadata': { u'rowIdentifier': 230641051 }, ... }
+
+Set the permissions of a dataset to public or private
+
+	>>> client.set_permission("/resource/eb9n-hr43.json", "public")
+	<Response [200]>
+
 Create a new row in an existing dataset
 
     >>> data = [{'Delegation': 'AJU', 'Name': 'Alaska', 'Key': 'AL', 'Entity': 'Juneau'}]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ Retrieving data is easy! Use SQL-style keyword args to filter data, or lookup an
     >>> client.get("/resource/nimj-3ivp/193.json", exclude_system_fields=False)
     {u'geolocation': {u'latitude': u'21.6711', u'needs_recoding': False, u'longitude': u'142.9236'}, u'version': u'C', u':updated_at': 1348778988, u'number_of_stations': u'136', u'region': u'Mariana Islands region', u':created_meta': u'21484', u'occurred_at': u'2012-09-13T11:19:07', u':id': 193, u'source': u'us', u'depth': u'300.70', u'magnitude': u'4.4', u':meta': u'{\n}', u':updated_meta': u'21484', u':position': 193, u'earthquake_id': u'c000cmsq', u':created_at': 1348778988}	
 
+Create a dataset
+
+	>>> columns = [{"fieldName": "delegation", "name": "Delegation", "dataTypeName": "text"}, {"fieldName": "members", "name": "Members", "dataTypeName": "number"}]
+	>>> tags = ["politics", "geography"]
+	>>> client.create("Delegates", description="List of delegates", columns=columns, row_identifier="delegation", tags=tags, category="Transparency")
+	{u'id': u'2frc-hyvj', u'name': u'Foo Bar', u'description': u'test dataset', u'publicationStage': u'unpublished', u'columns': [ { u'name': u'Foo', u'dataTypeName': u'text', u'fieldName': u'foo', ... }, { u'name': u'Bar', u'dataTypeName': u'number', u'fieldName': u'bar', ... } ], u'metadata': { u'rowIdentifier': 230641051 }, ... }
+
+Publish a dataset after creating it (take it out of 'working copy' mode)
+
+	>>> client.publish("/resource/eb9n-hr43.json")
+	{u'id': u'2frc-hyvj', u'name': u'Foo Bar', u'description': u'test dataset', u'publicationStage': u'unpublished', u'columns': [ { u'name': u'Foo', u'dataTypeName': u'text', u'fieldName': u'foo', ... }, { u'name': u'Bar', u'dataTypeName': u'number', u'fieldName': u'bar', ... } ], u'metadata': { u'rowIdentifier': 230641051 }, ... }
+
+Set the permissions of a dataset to public or private
+
+	>>> client.set_permission("/resource/eb9n-hr43.json", "public")
+	<Response [200]>
+
 Create a new row in an existing dataset
 
     >>> data = [{'Delegation': 'AJU', 'Name': 'Alaska', 'Key': 'AL', 'Entity': 'Juneau'}]

--- a/README.md
+++ b/README.md
@@ -94,6 +94,3 @@ Wrap up when you're finished.
 ## Run tests
 
     $ ./runtests tests/
-
-## TODO and known issues
-- Currently, the client does not support dataset creation. A new import API is under construction, and being tracked [here](https://github.com/socrata/soda-ruby/issues/13).

--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -78,23 +78,19 @@ class Socrata(object):
 
     def create(self, name, **kwargs):
         '''
-        Create a dataset, including the field types. Optionally, specify args:
+        Create a dataset, including the field types. Optionally, specify args such as:
             description : description of the dataset
             columns : list of columns (see docs/tests for list structure)
             category : must exist in /admin/metadata
+            tags : array of tag strings
             row_identifier : field name of primary key
-            public : whether or not the dataset should be publicly accessible
-            published : whether to keep the dataset in the "staging" phase or publish
+            public : whether to set permissions to public
+            published : whether to keep as working copy or publish
         '''
         public = kwargs.pop("public", False)
         published = kwargs.pop("published", False)
         
-        payload = {
-            "name": name,
-            "description": kwargs.pop("description", None),
-            "category": kwargs.pop("category", None),
-            "columns": kwargs.pop("columns", None)
-        }
+        payload = {"name": name}
         
         if("row_identifier" in kwargs):
             payload["metadata"] = {

--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -102,13 +102,14 @@ class Socrata(object):
         
         return self._perform_update("post", "/api/views.json", payload)
     
-    def set_public(self, resource):
+    def set_permission(self, resource, permission="private"):
         '''
-        After creating a dataset, use this method to make it public
+        Set a dataset's permissions to private or public
+        Options are private, public
         '''
         params = {
             "method": "setPermission",
-            "value": "public.read"
+            "value": "public.read" if permission == "public" else permission
         }
         resource = resource.rsplit("/", 1)[-1] # just get the dataset id
         

--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -62,7 +62,7 @@ class Socrata(object):
                                session_adapter["adapter"])
             self.uri_prefix = session_adapter["prefix"]
         else:
-            self.uri_prefix = "https"
+            self.uri_prefix = "https://"
 
     def authentication_validation(self, username, password, access_token):
         '''
@@ -230,20 +230,20 @@ class Socrata(object):
             raise Exception("Unknown request type. Supported request types are"
                             ": {0}".format(", ".join(request_type_methods)))
 
-        uri = "{0}://{1}{2}".format(self.uri_prefix, self.domain, resource)
+        uri = "{0}{1}{2}".format(self.uri_prefix, self.domain, resource)
 
         # set a timeout, just to be safe
         kwargs["timeout"] = 10
 
         response = getattr(self.session, request_type)(uri, **kwargs)
-
+        
         # handle errors
         if response.status_code not in (200, 202):
             _raise_for_status(response)
 
         # when responses have no content body (ie. delete, set_public), simply 
         # return the whole response
-        if not len(response.text):
+        if not response.text:
             return response
 
         # for other request types, return most useful data

--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -84,8 +84,6 @@ class Socrata(object):
             category : must exist in /admin/metadata
             tags : array of tag strings
             row_identifier : field name of primary key
-            public : whether to set permissions to public
-            published : whether to keep as working copy or publish
         '''
         public = kwargs.pop("public", False)
         published = kwargs.pop("published", False)
@@ -117,7 +115,8 @@ class Socrata(object):
     
     def publish(self, resource):
         '''
-        After creating a dataset, use this method to publish it
+        The create() method creates a dataset in a "working copy" state. 
+        This method publishes it.
         '''
         resource = resource.split("/", 1)[-1].split(".")[0] # just get the dataset id
         return self._perform_request("post", "/api/views/" + resource + "/publication.json")

--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -118,7 +118,7 @@ class Socrata(object):
         The create() method creates a dataset in a "working copy" state. 
         This method publishes it.
         '''
-        resource = resource.split("/", 1)[-1].split(".")[0] # just get the dataset id
+        resource = resource.rsplit("/", 1)[-1].split(".")[0] # just get the dataset id
         return self._perform_request("post", "/api/views/" + resource + "/publication.json")
 
     def get(self, resource, **kwargs):

--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -237,8 +237,8 @@ class Socrata(object):
         if response.status_code not in (200, 202):
             _raise_for_status(response)
 
-        # when responses have no content body (ie. delete, set_public), simply 
-        # return the whole response
+        # when responses have no content body (ie. delete, set_permission), 
+        # simply return the whole response
         if not response.text:
             return response
 

--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -95,8 +95,9 @@ class Socrata(object):
             "category": kwargs.pop("category", None),
             "columns": kwargs.pop("columns", None)
         }
+        
         if("row_identifier" in kwargs):
-            payload.metadata = {
+            payload["metadata"] = {
                 "rowIdentifier": kwargs.pop("row_identifier", None)
             }
         
@@ -110,8 +111,8 @@ class Socrata(object):
         After creating a dataset, use this method to make it public
         '''
         params = {
-            'method': 'setPermission',
-            'value': 'public.read'
+            "method": "setPermission",
+            "value": "public.read"
         }
         resource = resource.rsplit("/", 1)[-1] # just get the dataset id
         

--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -232,7 +232,7 @@ class Socrata(object):
         kwargs["timeout"] = 10
 
         response = getattr(self.session, request_type)(uri, **kwargs)
-        
+
         # handle errors
         if response.status_code not in (200, 202):
             _raise_for_status(response)

--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -80,6 +80,7 @@ class Socrata(object):
         '''
         Create a dataset, including the field types. Optionally, specify args:
             description : description of the dataset
+            columns : list of columns (see docs/tests for list structure)
             category : must exist in /admin/metadata
             row_identifier : field name of primary key
             public : whether or not the dataset should be publicly accessible
@@ -91,7 +92,8 @@ class Socrata(object):
         payload = {
             "name": name,
             "description": kwargs.pop("description", None),
-            "category": kwargs.pop("category", None)
+            "category": kwargs.pop("category", None),
+            "columns": kwargs.pop("columns", None)
         }
         if("row_identifier" in kwargs):
             payload.metadata = {

--- a/tests/test_data/create_foobar.txt
+++ b/tests/test_data/create_foobar.txt
@@ -1,0 +1,65 @@
+{
+    "id": "2frc-hyvj",
+    "name": "Foo Bar",
+    "averageRating": 0,
+    "createdAt": 1448018696,
+    "description": "test dataset",
+    "downloadCount": 0,
+    "newBackend": false,
+    "numberOfComments": 0,
+    "oid": 14929734,
+    "publicationAppendEnabled": false,
+    "publicationGroup": 5638965,
+    "publicationStage": "unpublished",
+    "rowIdentifierColumnId": 230641051,
+    "rowsUpdatedAt": 1448018697,
+    "rowsUpdatedBy": "gxfh-uqsf",
+    "tableId": 5638965,
+    "totalTimesRated": 0,
+    "viewCount": 0,
+    "viewLastModified": 1448018697,
+    "viewType": "tabular",
+    "columns": [
+        {
+            "id": 230641050,
+            "name": "Foo",
+            "dataTypeName": "text",
+            "fieldName": "foo",
+            "position": 1,
+            "renderTypeName": "text",
+            "tableColumnId": 32762225,
+            "format": {}
+        },
+        {
+            "id": 230641051,
+            "name": "Bar",
+            "dataTypeName": "number",
+            "fieldName": "bar",
+            "position": 2,
+            "renderTypeName": "number",
+            "tableColumnId": 32762226,
+            "format": {}
+        }
+    ],
+    "metadata": {
+        "rowIdentifier": 230641051
+    },
+    "owner": {},
+    "query": {},
+    "rights": [
+        "read",
+        "write",
+        "add",
+        "delete",
+        "grant",
+        "add_column",
+        "remove_column",
+        "update_column",
+        "update_view",
+        "delete_view"
+    ],
+    "tableAuthor": {},
+    "flags": [
+        "default"
+    ]
+}

--- a/tests/test_soda.py
+++ b/tests/test_soda.py
@@ -157,7 +157,6 @@ def test_create():
     # Test response
     assert isinstance(response, dict)
     assert len(response.get("id")) == 9
-    
     client.close()
 
 def test_set_public():
@@ -180,7 +179,23 @@ def test_set_public():
     request = adapter.request_history[0]
     assert "method" in request.qs
     assert "value" in request.qs
+    client.close()
     
+def test_publish():
+    mock_adapter = {}
+    mock_adapter["prefix"] = PREFIX
+    adapter = requests_mock.Adapter()
+    mock_adapter["adapter"] = adapter
+    client = Socrata(DOMAIN, APPTOKEN, username=USERNAME, password=PASSWORD,
+                     session_adapter=mock_adapter)
+    
+    response_data = "create_foobar.txt"
+    resource = "/api/views/songs/publication.json" # publish() removes .json
+    set_up_mock(adapter, "POST", response_data, 200, resource=resource)
+    
+    response = client.publish("/songs.json") # hard-coded so request uri is matched
+    assert isinstance(response, dict)
+    assert len(response.get("id")) == 9
     client.close()
 
 def set_up_mock(adapter, method, response, response_code,

--- a/tests/test_soda.py
+++ b/tests/test_soda.py
@@ -173,7 +173,7 @@ def test_set_permission():
     set_up_mock(adapter, "PUT", response_data, 200, resource=resource)
     
     # Test response
-    response = client.set_permission(PATH, permission="public")
+    response = client.set_permission(PATH, "public")
     assert response.status_code == 200
     
     # Test request
@@ -206,7 +206,7 @@ def set_up_mock(adapter, method, response, response_code,
         try:
             body = json.load(f)
         except ValueError:
-            body = None
+            body = None # for case of empty file (test_set_permission)
             
     uri = "{0}{1}{2}".format(PREFIX, DOMAIN, resource)
     headers = {

--- a/tests/test_soda.py
+++ b/tests/test_soda.py
@@ -124,14 +124,47 @@ def test_delete():
         assert isinstance(e, requests_mock.exceptions.NoMockAddress)
     finally:
         client.close()
+        
+def test_create():
+    mock_adapter = {}
+    mock_adapter["prefix"] = PREFIX
+    adapter = requests_mock.Adapter()
+    mock_adapter["adapter"] = adapter
+    client = Socrata(DOMAIN, APPTOKEN, username=USERNAME, password=PASSWORD,
+                     session_adapter=mock_adapter)
+    
+    response_data = "create_foobar.txt"
+    resource = "/api/views.json"
+    set_up_mock(adapter, "POST", response_data, 200, resource=resource)
+    
+    columns = [
+        {"fieldName": "foo", "name": "Foo", "dataTypeName": "text"},
+        {"fieldName": "bar", "name": "Bar", "dataTypeName": "number"}
+    ]
+    response = client.create("Foo Bar", description="test dataset", 
+                  columns=columns, row_identifier="bar")
+    
+    request = adapter.request_history[0]
+    request_payload = json.loads(request.text) # can't figure out how to use .json
+    
+    # Test request payload
+    for dataset_key in ["name", "description", "columns"]:
+        assert dataset_key in request_payload
 
+    for column_key in ["fieldName", "name", "dataTypeName"]:
+        assert column_key in request_payload["columns"][0]
+    
+    # Test response
+    assert isinstance(response, dict)
+    assert len(response.get("id")) == 9
+    client.close()
 
 def set_up_mock(adapter, method, response, response_code,
-                reason="OK", auth=None):
+                reason="OK", auth=None, resource=PATH):
     path = os.path.join(TEST_DATA_PATH, response)
     with open(path, "rb") as f:
         body = json.load(f)
-    uri = "{0}://{1}{2}".format(PREFIX, DOMAIN, PATH)
+    uri = "{0}://{1}{2}".format(PREFIX, DOMAIN, resource)
     headers = {
         "content-type": "application/json; charset=utf-8"
     }

--- a/tests/test_soda.py
+++ b/tests/test_soda.py
@@ -7,7 +7,7 @@ import inspect
 import json
 
 
-PREFIX = "http://"
+PREFIX = "https://"
 DOMAIN = "fakedomain.com"
 PATH = "/songs.json"
 APPTOKEN = "FakeAppToken"

--- a/tests/test_soda.py
+++ b/tests/test_soda.py
@@ -160,7 +160,7 @@ def test_create():
     assert len(response.get("id")) == 9
     client.close()
 
-def test_set_public():
+def test_set_permission():
     mock_adapter = {}
     mock_adapter["prefix"] = PREFIX
     adapter = requests_mock.Adapter()
@@ -173,13 +173,13 @@ def test_set_public():
     set_up_mock(adapter, "PUT", response_data, 200, resource=resource)
     
     # Test response
-    response = client.set_public(PATH)
+    response = client.set_permission(PATH, permission="public")
     assert response.status_code == 200
     
     # Test request
     request = adapter.request_history[0]
-    assert "method" in request.qs
-    assert "value" in request.qs
+    qs = request.url.split("?")[-1]
+    assert qs == "method=setPermission&value=public.read"
     client.close()
     
 def test_publish():

--- a/tests/test_soda.py
+++ b/tests/test_soda.py
@@ -194,7 +194,7 @@ def test_publish():
     resource = "/api/views/songs/publication.json" # publish() removes .json
     set_up_mock(adapter, "POST", response_data, 200, resource=resource)
     
-    response = client.publish("/songs.json") # hard-coded so request uri is matched
+    response = client.publish("/resource/songs.json") # hard-coded so request uri is matched
     assert isinstance(response, dict)
     assert len(response.get("id")) == 9
     client.close()

--- a/tests/test_soda.py
+++ b/tests/test_soda.py
@@ -157,6 +157,7 @@ def test_create():
     # Test response
     assert isinstance(response, dict)
     assert len(response.get("id")) == 9
+    
     client.close()
 
 def test_set_public():
@@ -171,13 +172,16 @@ def test_set_public():
     resource = "/api/views" + PATH
     set_up_mock(adapter, "PUT", response_data, 200, resource=resource)
     
+    # Test response
     response = client.set_public(PATH)
+    assert response.status_code == 200
     
+    # Test request
     request = adapter.request_history[0]
     assert "method" in request.qs
     assert "value" in request.qs
     
-    assert response.status_code == 200
+    client.close()
 
 def set_up_mock(adapter, method, response, response_code,
                 reason="OK", auth=None, resource=PATH):

--- a/tests/test_soda.py
+++ b/tests/test_soda.py
@@ -141,14 +141,15 @@ def test_create():
         {"fieldName": "foo", "name": "Foo", "dataTypeName": "text"},
         {"fieldName": "bar", "name": "Bar", "dataTypeName": "number"}
     ]
+    tags = ["foo", "bar"]
     response = client.create("Foo Bar", description="test dataset", 
-                  columns=columns, row_identifier="bar")
+                  columns=columns, tags=tags, row_identifier="bar")
     
     request = adapter.request_history[0]
     request_payload = json.loads(request.text) # can't figure out how to use .json
     
     # Test request payload
-    for dataset_key in ["name", "description", "columns"]:
+    for dataset_key in ["name", "description", "columns", "tags"]:
         assert dataset_key in request_payload
 
     for column_key in ["fieldName", "name", "dataTypeName"]:


### PR DESCRIPTION
~~**Not ready to merge yet**. This is a work in progress. Just opening the pull request to encourage discussion around the implementation.~~ (Update: Ready to merge)

I'm still new to python and would love feedback and suggestions. I figure there's also room to discuss things like `columns`, and the fact that creating a dataset is actually 3 HTTP requests (create, set public, publish). Here's what I have so far.

Edit: Another thing worth discussing is the fact that this uses the new API, so `/resource/asdf-asdf.json` is not the correct path (it's `/api/views/asdf-asdf.json`). I'd make the argument for abstracting the resource in the library and only looking for the 4x4 dataset ID. This way it would be very easy to switch from the old API to the new one, even for reading/GETs. I imagine in order to make this a non-breaking change, we'd have to allow the `/resource/xxxx.json` usage and just trim it off the string as I've done in this pull request.