### PR TITLE
New backend option

### DIFF
--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -87,19 +87,19 @@ class Socrata(object):
         '''
         public = kwargs.pop("public", False)
         published = kwargs.pop("published", False)
-        
+
         payload = {"name": name}
-        
+
         if("row_identifier" in kwargs):
             payload["metadata"] = {
                 "rowIdentifier": kwargs.pop("row_identifier", None)
             }
-        
+
         payload.update(kwargs)
         payload = _clear_empty_values(payload)
-        
+
         return self._perform_update("post", "/api/views.json", payload)
-    
+
     def set_permission(self, resource, permission="private"):
         '''
         Set a dataset's permissions to private or public
@@ -110,9 +110,9 @@ class Socrata(object):
             "value": "public.read" if permission == "public" else permission
         }
         resource = resource.rsplit("/", 1)[-1] # just get the dataset id
-        
+
         return self._perform_request("put", "/api/views/" + resource, params=params)
-    
+
     def publish(self, resource):
         '''
         The create() method creates a dataset in a "working copy" state. 

--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -84,9 +84,10 @@ class Socrata(object):
             category : must exist in /admin/metadata
             tags : array of tag strings
             row_identifier : field name of primary key
+            new_backend : whether to create the dataset in the new backend
         '''
-        public = kwargs.pop("public", False)
-        published = kwargs.pop("published", False)
+        new_backend = kwargs.pop("new_backend", False)
+        resource = "/api/views.json" + ("?nbe=true" if new_backend else "")
 
         payload = {"name": name}
 
@@ -98,7 +99,7 @@ class Socrata(object):
         payload.update(kwargs)
         payload = _clear_empty_values(payload)
 
-        return self._perform_update("post", "/api/views.json", payload)
+        return self._perform_update("post", resource, payload)
 
     def set_permission(self, resource, permission="private"):
         '''

--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -82,12 +82,14 @@ class Socrata(object):
             description : description of the dataset
             columns : list of columns (see docs/tests for list structure)
             category : must exist in /admin/metadata
-            tags : array of tag strings
+            tags : list of tag strings
             row_identifier : field name of primary key
             new_backend : whether to create the dataset in the new backend
         '''
         new_backend = kwargs.pop("new_backend", False)
-        resource = "/api/views.json" + ("?nbe=true" if new_backend else "")
+        resource = "/api/views.json"
+        if new_backend:
+          resource += "?nbe=true"
 
         payload = {"name": name}
 


### PR DESCRIPTION
I found out today from Socrata that `?nbe=true` can be used to create the dataset in the new backend. They advised that this should be used for (a) geospatial datasets, and (b) huge tabular datasets (15-20 million rows). For everything else, the old backend should be used for now, since the new backend doesn't support everything just yet (ie. export formats).

I also removed that whitespace on empty lines that I created in my last PR. My bad.

Note that I imagine in a few months this won't be necessary as all dataset creation will automatically be in the new backend.