### PR TITLE
Adding extra attachment handling that closes #25

### DIFF
--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -159,10 +159,18 @@ class Socrata(object):
 
         for attachment in attachments:
             file_path = os.path.join(download_dir, attachment["filename"])
-            base = _format_old_api_request(dataid=dataset_identifier)
-            resource = "{0}/files/{1}?download=true&filename={2}".format(base,
-                                                                         attachment["assetId"],
+            has_assetid = attachment.get("assetId", False)
+            if has_assetid:
+                base = _format_old_api_request(dataid=dataset_identifier)
+                assetid = attachment["assetId"]
+                resource = "{0}/files/{1}?download=true&filename={2}".format(base,
+                                                                         assetid,
                                                                          attachment["filename"])
+            else:
+                base = "/api/assets"
+                assetid = attachment["blobId"]
+                resource = "{0}/{1}?download=true".format(base, assetid)
+
             uri = "{0}{1}{2}".format(self.uri_prefix, self.domain, resource)
             _download_file(uri, file_path)
             files.append(file_path)


### PR DESCRIPTION
This is a fairly low-interruption patch that is tested directly against the NYC open data portal (using the following dataset identifiers: a94k-kjys, 3av7-txd8, 7isb-wh4c, 72ss-25qh). 

I thought to write a test for this, but since there are no existing tests for the `download_attachments` method, I wasn't sure what was the best way to do that given the way other tests were written. I can do so with a little guidance, but perhaps have a look first.

Also, I figure the change is pretty straight forward (just addressed how the URL to the attachment is formatted) and of course the change does not break any existing tests.