### PR TITLE
Fix typo

### DIFF
--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -166,7 +166,7 @@ class Socrata(object):
         for key in kwargs:
             if key not in all_filters:
                 raise TypeError("Unexpected keyword argument %s" % key)
-        params = [('domain', self.domain)]
+        params = [('domains', self.domain)]
         if limit:
             params.append(('limit', limit))
         for key, value in kwargs.items():


### PR DESCRIPTION
I come to you beaten and ashamed. My database just wiped itself clean after getting no dataset from Socrata, because I messed this up again. The correct parameter is domain**s**, otherwise you get `[]`, I am so sorry.

This fixes #57 which was supposed to fix #53, but didn't, because I did not test this right. I did this time, installing from my fork and running my system which is getting datasets as expected.

I am so very sorry.