### PR TITLE
Remove python2 support. Fixes #62.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: python
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 install:
   - "pip install -r requirements-dev.txt"
   - "python setup.py install"
 before_script:
   - "flake8 sodapy/"
   - "flake8 tests/"
-script: pytest
+script:
+  - pytest

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you want to install from source, then clone this repository and run `python s
 
 ## Requirements
 
-At its core, this library depends heavily on the [Requests](http://docs.python-requests.org/en/latest/) package. All other requirements can be found in [requirements.txt](https://github.com/xmunoz/sodapy/blob/master/requirements.txt). `sodapy` is currently compatible with Python 2.7, 3.4, 3.5, 3.6, and 3.7.
+At its core, this library depends heavily on the [Requests](http://docs.python-requests.org/en/latest/) package. All other requirements can be found in [requirements.txt](https://github.com/xmunoz/sodapy/blob/master/requirements.txt). `sodapy` is currently compatible with Python 3.4, 3.5, 3.6, 3.7 and 3.8.
 
 ## Documentation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-future>=0.17.1
 requests>=2.20.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 from setuptools import setup
 
@@ -29,10 +28,11 @@ kwargs = {
     "download_url": "https://github.com/xmunoz/sodapy/archive/master.tar.gz",
     "keywords": "soda socrata opendata api",
     "classifiers": [
-        "Programming Language :: Python",
-        "Topic :: Software Development",
-        "Topic :: Software Development :: Libraries",
+        "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Libraries :: Python Modules",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Development Status :: 5 - Production/Stable",
     ]
 }
 

--- a/sodapy/__init__.py
+++ b/sodapy/__init__.py
@@ -1,9 +1,3 @@
-from __future__ import absolute_import
-from future import standard_library
-
-standard_library.install_aliases()
-
-from builtins import object
 from io import StringIO, IOBase
 import requests
 import csv
@@ -15,7 +9,7 @@ import os
 from .constants import DEFAULT_API_PATH, OLD_API_PATH, DATASETS_PATH
 
 
-class Socrata(object):
+class Socrata:
     '''
     The main class that interacts with the SODA API. Sample usage:
         from sodapy import Socrata
@@ -419,16 +413,10 @@ class Socrata(object):
         Execute the update task.
         '''
 
-        # python2/3 compatibility wizardry
-        try:
-            file_type = file
-        except NameError:
-            file_type = IOBase
-
         if isinstance(payload, (dict, list)):
             response = self._perform_request(method, resource,
                                              data=json.dumps(payload))
-        elif isinstance(payload, file_type):
+        elif isinstance(payload, IOBase):
             headers = {
                 "content-type": "text/csv",
             }

--- a/sodapy/version.py
+++ b/sodapy/version.py
@@ -1,2 +1,2 @@
-version_info = (1, 5, 5)
+version_info = (2, 0, 0)
 __version__ = '.'.join(str(v) for v in version_info)


### PR DESCRIPTION
- Add support for python 3.8
- Update trove classifiers
- Brutally excise all vestiges of python 2